### PR TITLE
Added LensDirt Texture Saving

### DIFF
--- a/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
@@ -1,8 +1,7 @@
 ﻿using UnityEngine;
 using static AIGraphics.Inspector.Util;
 
-namespace AIGraphics.Inspector
-{
+namespace AIGraphics.Inspector {
     internal class Inspector
     {
         private static Rect _windowRect;

--- a/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
@@ -9,7 +9,6 @@ namespace AIGraphics.Inspector
 {
     internal static class PostProcessingInspector
     {
-        private static int selectedLensDirtIndex = -1;
         private static Vector2 postScrollView;
         private static int selectedVolumeIndex = 0;
         private static PostProcessVolume selectedVolume;
@@ -179,9 +178,13 @@ namespace AIGraphics.Inspector
                 SliderColor("Colour", settings.bloomLayers[volumeIndex].color.value, colour => { settings.bloomLayers[volumeIndex].color.value = colour; }, settings.bloomLayers[volumeIndex].color.overrideState,
                     settings.bloomLayers[volumeIndex].color.overrideState, overrideState => settings.bloomLayers[volumeIndex].color.overrideState = overrideState);
                 settings.bloomLayers[volumeIndex].fastMode.value = Toggle("Fast Mode", settings.bloomLayers[volumeIndex].fastMode.value);
-                selectedLensDirtIndex = SelectionTexture("Lens Dirt", selectedLensDirtIndex, postprocessingManager.LensDirtPreviews.ToArray(), Inspector.Width / 100,
+
+                PostProcessingManager.currentDirtIndex = SelectionTexture("Lens Dirt", PostProcessingManager.currentDirtIndex, postprocessingManager.LensDirtPreviews.ToArray(), Inspector.Width / 100,
                     settings.bloomLayers[volumeIndex].dirtTexture.overrideState, overrideState => settings.bloomLayers[volumeIndex].dirtTexture.overrideState = overrideState, GUIStyles.Skin.box);
-                if (-1 != selectedLensDirtIndex) settings.bloomLayers[volumeIndex].dirtTexture.value = postprocessingManager.LensDirts.ToArray()[selectedLensDirtIndex];
+                if (-1 != PostProcessingManager.currentDirtIndex) {
+                    settings.bloomLayers[volumeIndex].dirtTexture.value = PostProcessingManager.DirtTexture;
+                }
+
                 settings.bloomLayers[volumeIndex].dirtIntensity.value = Text("Dirt Intensity", settings.bloomLayers[volumeIndex].dirtIntensity.value, "N2",
                     settings.bloomLayers[volumeIndex].dirtIntensity.overrideState, overrideState => settings.bloomLayers[volumeIndex].dirtIntensity.overrideState = overrideState);
             }

--- a/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
@@ -179,7 +179,7 @@ namespace AIGraphics.Inspector
                     settings.bloomLayers[volumeIndex].color.overrideState, overrideState => settings.bloomLayers[volumeIndex].color.overrideState = overrideState);
                 settings.bloomLayers[volumeIndex].fastMode.value = Toggle("Fast Mode", settings.bloomLayers[volumeIndex].fastMode.value);
 
-                PostProcessingManager.currentDirtIndex = SelectionTexture("Lens Dirt", PostProcessingManager.currentDirtIndex, postprocessingManager.LensDirtPreviews.ToArray(), Inspector.Width / 100,
+                PostProcessingManager.currentDirtIndex = SelectionTexture("Lens Dirt", PostProcessingManager.currentDirtIndex, PostProcessingManager.LensDirtPreviews.ToArray(), Inspector.Width / 100,
                     settings.bloomLayers[volumeIndex].dirtTexture.overrideState, overrideState => settings.bloomLayers[volumeIndex].dirtTexture.overrideState = overrideState, GUIStyles.Skin.box);
                 if (-1 != PostProcessingManager.currentDirtIndex) {
                     settings.bloomLayers[volumeIndex].dirtTexture.value = PostProcessingManager.DirtTexture;

--- a/AI_Graphics/AI_Graphics/PostProcessingManager.cs
+++ b/AI_Graphics/AI_Graphics/PostProcessingManager.cs
@@ -9,9 +9,19 @@ namespace AIGraphics
     internal class PostProcessingManager : MonoBehaviour
     {
         private string _lensDirtTexturePath;
-        internal List<string> LensDirtPaths { get; private set; }
+        // Texture Lists don't have to be instanced.
+        internal static List<string> LensDirtPaths { get; private set; }
+        internal static List<Texture2D> LensDirts { get; private set; }
         internal List<Texture2D> LensDirtPreviews { get; private set; }
-        internal List<Texture2D> LensDirts { get; private set; }
+        internal static int currentDirtIndex = -1;
+
+        internal static Texture2D DirtTexture {
+            get => LensDirts.ToArray()[currentDirtIndex];
+        }
+        internal static string DirtTexturePath {
+            get => LensDirtPaths.ToArray()[currentDirtIndex];
+        }
+        public static int FindIndexByPath(string path) => LensDirtPaths.FindIndex(x => x.Equals(path));
 
         internal string LensDirtTexturesPath
         {

--- a/AI_Graphics/AI_Graphics/PostProcessingManager.cs
+++ b/AI_Graphics/AI_Graphics/PostProcessingManager.cs
@@ -12,7 +12,7 @@ namespace AIGraphics
         // Texture Lists don't have to be instanced.
         internal static List<string> LensDirtPaths { get; private set; }
         internal static List<Texture2D> LensDirts { get; private set; }
-        internal List<Texture2D> LensDirtPreviews { get; private set; }
+        internal static List<Texture2D> LensDirtPreviews { get; private set; }
         internal static int currentDirtIndex = -1;
 
         internal static Texture2D DirtTexture {

--- a/AI_Graphics/AI_Graphics/Setting/PostProcessingParameters.cs
+++ b/AI_Graphics/AI_Graphics/Setting/PostProcessingParameters.cs
@@ -112,7 +112,8 @@ namespace AIGraphics.Settings {
         public bool fastMode;
         public string dirtTexture;
         public float dirtIntensity;
-        public void Save(UnityEngine.Rendering.PostProcessing.Bloom layer, string dirtTexturePath = "") {
+
+        public void Save(UnityEngine.Rendering.PostProcessing.Bloom layer) {
             if (layer != null) {
                 enabled = layer.enabled.value;
                 intensity = layer.intensity.value;
@@ -124,8 +125,9 @@ namespace AIGraphics.Settings {
                 color = new float[3] { layer.color.value[0], layer.color.value[1], layer.color.value[2] };
                 fastMode = layer.fastMode.value;
                 dirtIntensity = layer.dirtIntensity.value;
-                // Save Path
-                dirtTexture = dirtTexturePath;
+                dirtTexture = PostProcessingManager.DirtTexturePath;
+                // dirtTexture is getting saved when dirtTexture is being set from PostProcessingSettings.
+                // ref: PostProcessingSettings.cs:167
             }
         }
         public void Load(UnityEngine.Rendering.PostProcessing.Bloom layer) {
@@ -141,8 +143,9 @@ namespace AIGraphics.Settings {
                 layer.fastMode.value = fastMode;
                 layer.dirtIntensity.value = dirtIntensity;
 
-                // Load from path.
-                // layer.dirtTexture.value = dirtTexture
+                int textureIndex = PostProcessingManager.FindIndexByPath(dirtTexture);
+                if (textureIndex > 0) // found texture index?
+                    layer.dirtTexture.value = PostProcessingManager.LensDirts[textureIndex];
             }
         }
     }

--- a/AI_Graphics/AI_Graphics/Setting/PostProcessingSettings.cs
+++ b/AI_Graphics/AI_Graphics/Setting/PostProcessingSettings.cs
@@ -163,10 +163,6 @@ namespace AIGraphics.Settings {
         internal Transform VolumeTriggerSetting {
             get => _postProcessLayer.volumeTrigger;
         }
-        
-        internal string BloomTexturePath {
-            set => this.paramBloom.dirtTexture = value;
-        }
 
         public LayerMask VolumeLayerSetting {
             //get => LayerMask.LayerToName(_postProcessLayer.volumeLayer.value);

--- a/AI_Graphics/AI_Graphics/Setting/PostProcessingSettings.cs
+++ b/AI_Graphics/AI_Graphics/Setting/PostProcessingSettings.cs
@@ -163,6 +163,10 @@ namespace AIGraphics.Settings {
         internal Transform VolumeTriggerSetting {
             get => _postProcessLayer.volumeTrigger;
         }
+        
+        internal string BloomTexturePath {
+            set => this.paramBloom.dirtTexture = value;
+        }
 
         public LayerMask VolumeLayerSetting {
             //get => LayerMask.LayerToName(_postProcessLayer.volumeLayer.value);
@@ -239,10 +243,9 @@ namespace AIGraphics.Settings {
         }
         public BloomParams Bloom {
             get => paramBloom;
-            set {
-                paramBloom = value;
-            }
+            set => paramBloom = value;
         }
+
         public ChromaticAberrationParams ChromaticAberration {
             get => paramChromaticAberration;
             set {


### PR DESCRIPTION
**Notable changes:**
Changed PostProcessingManager
- DirtLists are no longer get  instanced.
- Saves path of Dirt Texture, Try to find index of dirt texture path from manager when loading the preset.

This Merge Request will close #6