### PR TITLE
Add Preset Save/Load UI

### DIFF
--- a/AI_Graphics/AI_Graphics/AIGraphics.cs
+++ b/AI_Graphics/AI_Graphics/AIGraphics.cs
@@ -1,5 +1,6 @@
 ﻿using AIGraphics.Inspector;
 using AIGraphics.Settings;
+using AIProject;
 using BepInEx;
 using BepInEx.Configuration;
 using KKAPI;
@@ -40,6 +41,7 @@ namespace AIGraphics
         private FocusPuller _focusPuller;
         private LightManager _lightManager;
         private PostProcessingManager _postProcessingManager;
+        private PresetManager _presetManager;
         private Inspector.Inspector _inspector;
 
         internal GlobalSettings Settings { get; private set; }
@@ -55,7 +57,7 @@ namespace AIGraphics
                 throw new InvalidOperationException("Can only create one instance of AIGraphics");
             Instance = this;
 
-            ConfigPresetPath = Config.Bind("Config", "Preset Location", Application.dataPath + "/../iblpresets/", new ConfigDescription("Where presets are stored"));
+            ConfigPresetPath = Config.Bind("Config", "Preset Location", Application.dataPath + "/../presets/", new ConfigDescription("Where presets are stored"));
             ConfigCubeMapPath = Config.Bind("Config", "Cubemap path", Application.dataPath + "/../cubemaps/", new ConfigDescription("Where cubemaps are stored"));
             ConfigLensDirtPath = Config.Bind("Config", "Lens dirt texture path", Application.dataPath + "/../lensdirts/", new ConfigDescription("Where lens dirt textures are stored"));
             ConfigFontSize = Config.Bind("Config", "Font Size", 12, new ConfigDescription("Font Size"));
@@ -110,6 +112,8 @@ namespace AIGraphics
             _focusPuller.init(this, CameraSettings.MainCamera);
 
             _lightManager = new LightManager(this);
+
+            _presetManager = new PresetManager(ConfigPresetPath.Value, this);
             
             _inspector = new Inspector.Inspector(this);
 
@@ -117,15 +121,13 @@ namespace AIGraphics
             yield return new WaitUntil(() => {
                 return (KoikatuAPI.GetCurrentGameMode() == GameMode.Studio) ? KKAPI.Studio.StudioAPI.InsideStudio && _skyboxManager != null : true;
             });
-
-            preset = new Preset(Settings, CameraSettings, LightingSettings, PostProcessingSettings, SkyboxManager.skyboxParams);
-            preset.Load();
         }
 
         internal SkyboxManager SkyboxManager { get => _skyboxManager; }
         internal PostProcessingManager PostProcessingManager { get => _postProcessingManager; }
         internal LightManager LightManager { get => _lightManager; }
         internal FocusPuller FocusPuller { get => _focusPuller; }
+        internal PresetManager PresetManager { get => _presetManager; }
 
         internal void OnGUI()
         {

--- a/AI_Graphics/AI_Graphics/AIGraphics.cs
+++ b/AI_Graphics/AI_Graphics/AIGraphics.cs
@@ -1,6 +1,5 @@
 ﻿using AIGraphics.Inspector;
 using AIGraphics.Settings;
-using AIProject;
 using BepInEx;
 using BepInEx.Configuration;
 using KKAPI;

--- a/AI_Graphics/AI_Graphics/AIGraphics.csproj
+++ b/AI_Graphics/AI_Graphics/AIGraphics.csproj
@@ -105,9 +105,11 @@
     <Compile Include="Inspector\LightingInspector.cs" />
     <Compile Include="Inspector\LightInspector.cs" />
     <Compile Include="Inspector\PostProcessingInspector.cs" />
+    <Compile Include="Inspector\PresetInspector.cs" />
     <Compile Include="LightManager.cs" />
     <Compile Include="PostProcessingManager.cs" />
     <Compile Include="Preset.cs" />
+    <Compile Include="PresetManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionExtensions.cs" />
     <Compile Include="SceneController.cs" />

--- a/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
@@ -7,7 +7,7 @@ namespace AIGraphics.Inspector
     {
         private static Rect _windowRect;
         private int _windowID = 0;
-        private enum Tab { Lighting, Lights, PostProcessing, Settings };
+        private enum Tab { Lighting, Lights, PostProcessing, Presets, Settings };
         private Tab SelectedTab { get; set; }
         internal AIGraphics Parent { get; set; }
 
@@ -80,6 +80,9 @@ namespace AIGraphics.Inspector
                     break;
                 case Tab.PostProcessing:
                     PostProcessingInspector.Draw(Parent.PostProcessingSettings, Parent.PostProcessingManager, Parent.FocusPuller, Parent.Settings.ShowAdvancedSettings);
+                    break;
+                case Tab.Presets:
+                    PresetInspector.Draw(Parent.PresetManager);
                     break;
                 case Tab.Settings:
                     SettingsInspector.Draw(Parent.CameraSettings, Parent.Settings, Parent);

--- a/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
@@ -31,7 +31,7 @@ namespace AIGraphics.Inspector
                 //inactivate controls if no cubemap
                 if (skyboxManager.CubemapPaths.IsNullOrEmpty())
                 {
-                    GUILayout.Label("No custom cubemap found");
+                    GUILayout.Label("No custom cubemaps found");
                 }
                 else
                 {

--- a/AI_Graphics/AI_Graphics/Inspector/PresetInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/PresetInspector.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using UnityEngine;
+using static AIGraphics.Inspector.Util;
+
+namespace AIGraphics.Inspector
+{
+    internal static class PresetInspector
+    {
+        private const string _nameCue = "(preset name)";
+        private static string _nameToSave = _nameCue;
+
+        private static Vector2 presetScrollView;
+        internal static void Draw(PresetManager presetManager)
+        {
+            GUILayout.BeginVertical(GUIStyles.Skin.box);
+            GUILayout.Label("Presets");
+            GUILayout.Space(1);
+            if (presetManager.PresetNames.IsNullOrEmpty())
+            {
+                GUILayout.Label("No presets found");
+            }
+            else
+            {
+                presetScrollView = GUILayout.BeginScrollView(presetScrollView);
+                int selectedPresetIdx = Array.IndexOf(presetManager.PresetNames, presetManager.CurrentPreset);
+                selectedPresetIdx = GUILayout.SelectionGrid(selectedPresetIdx, presetManager.PresetNames, Inspector.Width / 150);
+                if (-1 != selectedPresetIdx) presetManager.CurrentPreset = presetManager.PresetNames[selectedPresetIdx];
+                GUILayout.EndScrollView();
+            }
+            GUILayout.Space(1);
+            GUILayout.BeginHorizontal();
+            _nameToSave = GUILayout.TextField(_nameToSave);
+            bool isValidFileName = (0 != _nameToSave.Length && 256 >= _nameToSave.Length);
+            bool isCue = (_nameCue == _nameToSave);
+            if (GUILayout.Button("Save", GUILayout.ExpandWidth(false)) && isValidFileName && !isCue )
+                presetManager.Save(_nameToSave);
+            GUILayout.EndHorizontal();
+            GUILayout.Space(1);
+            if (!isCue && !isValidFileName )
+                GUILayout.Label("Please specify a valid file name.");
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
@@ -48,12 +48,6 @@ namespace AIGraphics.Inspector
                 Slider("Window Height", Inspector.Height, 400, Screen.height, size => Inspector.Height = size);
                 GUILayout.Space(10);
                 renderingSettings.ShowAdvancedSettings = Toggle("Show Advanced Settings", renderingSettings.ShowAdvancedSettings);
-                if (GUILayout.Button("Save Default Preset")) {
-                    parent.preset.Save();
-                }
-                if (GUILayout.Button("Load Default Preset")) {
-                    parent.preset.Load();
-                }
             }
             GUILayout.EndVertical();
         }

--- a/AI_Graphics/AI_Graphics/Preset.cs
+++ b/AI_Graphics/AI_Graphics/Preset.cs
@@ -51,14 +51,11 @@ namespace AIGraphics {
                 try {
                     byte[] bytes = File.ReadAllBytes(targetPath);
                     Load(bytes);
-                    Debug.Log(string.Format("Loaded preset file '{0}'", name + ".preset"));
                     return true;
                 } catch {
-                    Debug.Log(string.Format("Failed to load preset file '{0}'", name + ".preset"));
                     return false;
                 }
             } else {
-                Debug.Log(string.Format("Couldn't find preset file '{0}'", name + ".preset"));
                 return false;
             }
         }

--- a/AI_Graphics/AI_Graphics/Preset.cs
+++ b/AI_Graphics/AI_Graphics/Preset.cs
@@ -53,9 +53,11 @@ namespace AIGraphics {
                     Load(bytes);
                     return true;
                 } catch {
+                    Debug.Log(string.Format("Failed to load preset file '{0}'", name + ".preset"));
                     return false;
                 }
             } else {
+                Debug.Log(string.Format("Couldn't find preset file '{0}'", name + ".preset"));
                 return false;
             }
         }

--- a/AI_Graphics/AI_Graphics/PresetManager.cs
+++ b/AI_Graphics/AI_Graphics/PresetManager.cs
@@ -1,0 +1,87 @@
+﻿using UnityEngine;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using ADV.Commands.Object;
+using ADV.Commands.Base;
+using ExtensibleSaveFormat;
+
+namespace AIGraphics
+{
+    internal class PresetManager 
+    {
+        private string _path;
+        private string _currentPresetName;
+        private FolderAssist _presetFolder;
+        private Dictionary<string, string> _presetNameToPath;
+        private AIGraphics _parent;
+
+        internal PresetManager(string presetPath, AIGraphics parent)
+        {
+            _path = presetPath;
+            _parent = parent;
+            LoadPresets();
+        }
+
+        private void LoadPresets()
+        {
+            _presetFolder = new FolderAssist();
+            _presetFolder.CreateFolderInfo(_path, "*.preset", true, true);
+            _presetNameToPath = _presetFolder.lstFile.ToDictionary(entry => entry.FileName, entry => entry.FullPath);
+        }
+
+        internal string PresetPath(string presetName)
+        {
+            return _presetNameToPath.TryGetValue(presetName, out string presetPath) ? presetPath : "";
+        }
+        internal string[] PresetNames { get => _presetNameToPath.Keys.ToArray(); }
+
+        internal string CurrentPreset 
+        { 
+            get => _currentPresetName; 
+            set
+            {
+                Load(value);
+                _currentPresetName = value;
+            }
+        }
+
+        internal void Save(string presetName)
+        {
+            Preset preset = new Preset(_parent.Settings, _parent.CameraSettings, _parent.LightingSettings, _parent.PostProcessingSettings, _parent.SkyboxManager.skyboxParams);
+            preset.Save(presetName);
+            LoadPresets();
+        }
+
+        internal PluginData GetExtendedData()
+        {
+            Preset preset = new Preset(_parent.Settings, _parent.CameraSettings, _parent.LightingSettings, _parent.PostProcessingSettings, _parent.SkyboxManager.skyboxParams);
+            PluginData saveData = new PluginData();
+            preset.UpdateParameters();
+            byte[] presetData = preset.Serialize();
+            saveData.data.Add("bytes", presetData);
+            saveData.version = 1;
+            return saveData;
+        }
+
+        internal bool Load(string presetName)
+        {
+            Preset preset = new Preset(_parent.Settings, _parent.CameraSettings, _parent.LightingSettings, _parent.PostProcessingSettings, _parent.SkyboxManager.skyboxParams);
+            return preset.Load(presetName); ;
+        }
+
+        internal void Load(PluginData data)
+        {
+            if (data != null && data.data.TryGetValue("bytes", out var val))
+            {
+                byte[] presetData = (byte[])val;
+                if (!presetData.IsNullOrEmpty())
+                {
+                    Preset preset = new Preset(_parent.Settings, _parent.CameraSettings, _parent.LightingSettings, _parent.PostProcessingSettings, _parent.SkyboxManager.skyboxParams);
+                    preset.Load(presetData);
+                }
+            }
+        }
+    }
+}

--- a/AI_Graphics/AI_Graphics/SceneController.cs
+++ b/AI_Graphics/AI_Graphics/SceneController.cs
@@ -12,25 +12,14 @@ namespace AIGraphics
         protected override void OnSceneLoad(SceneOperationKind operation, ReadOnlyDictionary<int, ObjectCtrlInfo> loadedItems)
         {
             Studio.Studio studio = GetStudio();
-            AIGraphics parent = GetComponentInParent<AIGraphics>();            
+            AIGraphics parent = AIGraphics.Instance;
             parent?.SkyboxManager?.SetupDefaultReflectionProbe();
-
-            PluginData saveData = GetExtendedData();
-            if (saveData != null && saveData.data.TryGetValue("bytes", out var val)) {
-                byte[] presetData = (byte[])val;
-                if (!presetData.IsNullOrEmpty())
-                    AIGraphics.Instance.preset.Load((byte[])presetData);
-            }
+            parent?.PresetManager?.Load(GetExtendedData());
         }
 
         protected override void OnSceneSave()
         {
-            PluginData saveData = new PluginData();
-            AIGraphics.Instance.preset.UpdateParameters();
-            byte[] presetData = AIGraphics.Instance.preset.Serialize();
-            saveData.data.Add("bytes", presetData);
-            saveData.version = 1;
-            SetExtendedData(saveData);
+            SetExtendedData(AIGraphics.Instance?.PresetManager.GetExtendedData());
         }
     }
 }


### PR DESCRIPTION
fixes #10 
* this saves to /loads specific prefix and removed the default preset load. If we want a default preset to be loaded, we can add that as an option for the user in a subsequent change.