### PR TITLE
Bug - re-entering maker

### DIFF
--- a/AI_Graphics/AI_Graphics/AIGraphics.cs
+++ b/AI_Graphics/AI_Graphics/AIGraphics.cs
@@ -35,7 +35,6 @@ namespace AIGraphics
         private CursorLockMode _previousCursorLockState;
         private bool _previousCursorVisible;
 
-        private GameObject _skyboxGO, _postGO;
         private SkyboxManager _skyboxManager;
         private FocusPuller _focusPuller;
         private LightManager _lightManager;
@@ -94,21 +93,18 @@ namespace AIGraphics
             Settings = new GlobalSettings();
             CameraSettings = new CameraSettings();
             LightingSettings = new LightingSettings();
-            PostProcessingSettings = new PostProcessingSettings(CameraSettings.MainCamera);            
+            PostProcessingSettings = new PostProcessingSettings(CameraSettings.MainCamera);
 
-            _skyboxGO = new GameObject("SkyboxManager");
-            _skyboxManager = _skyboxGO.AddComponent<SkyboxManager>();
+            _skyboxManager = Instance.GetOrAddComponent<SkyboxManager>();            
             _skyboxManager.Parent = this;
-            _skyboxManager.Camera = CameraSettings.MainCamera;
             _skyboxManager.CubemapPath = ConfigCubeMapPath.Value;
             _skyboxManager.Logger = Logger;
 
-            _postGO = new GameObject("PostProcessingManager");
-            _postProcessingManager = _postGO.AddComponent<PostProcessingManager>();
+            _postProcessingManager = Instance.GetOrAddComponent<PostProcessingManager>();
             _postProcessingManager.LensDirtTexturesPath = ConfigLensDirtPath.Value;
-
-            _focusPuller = CameraSettings.MainCamera.gameObject.AddComponent<FocusPuller>();
-            _focusPuller.init(this, CameraSettings.MainCamera);
+            
+            _focusPuller = Instance.GetOrAddComponent<FocusPuller>();
+            _focusPuller.init(this);
 
             _lightManager = new LightManager(this);
 

--- a/AI_Graphics/AI_Graphics/FocusPuller.cs
+++ b/AI_Graphics/AI_Graphics/FocusPuller.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ADV.Commands.Base;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,15 +16,22 @@ namespace AIGraphics
         float _velocity;
         Vector3 lastDoFPoint;
         bool initialFrame;
-        private Camera _camera;
-        public GameObject FocusTarget = new GameObject("FocusTarget");
+        private GameObject _ftgo;
+        private Transform _target;
         public LayerMask hitLayer;
-        public float maxDistance;
+        public float maxDistance;        
 
-        [SerializeField] Transform _target;
-        public Transform target
-        {
-            get => _target;
+        public Transform FocusTarget 
+        { 
+            get
+            {
+                if(!_target)
+                {
+                    _ftgo = new GameObject("FocusTarget");
+                    _target = _ftgo.transform;
+                }
+                return _target;
+            }
             set => _target = value;
         }
 
@@ -34,18 +42,17 @@ namespace AIGraphics
             set { _speed = Mathf.Max(0.01f, value); }
         }
 
-        public void init(AIGraphics parent, Camera camera)
+        public void init(AIGraphics parent)
         {
             _parent = parent;
-            _camera = camera;
-            hitLayer = camera.cullingMask;
-            maxDistance = camera.farClipPlane;
+            hitLayer = _parent.CameraSettings.MainCamera.cullingMask;
+            maxDistance = _parent.CameraSettings.MainCamera.farClipPlane;
         }
 
         void Awake()
         {
             Physics.queriesHitBackfaces = true;            
-            _target = FocusTarget.transform;
+
         }
         void OnEnable()
         {
@@ -56,7 +63,6 @@ namespace AIGraphics
             speed = _speed;
         }
 
-        //void OnPreRender()
         void LateUpdate()
         {
             if (initialFrame)
@@ -70,10 +76,10 @@ namespace AIGraphics
             // Retrieve the current value.
             var d1 = _parent.PostProcessingSettings.FocalDistance;//_controller.depthOfField.focusDistance;
 
-            Debug.DrawLine(transform.position, _target.position, Color.green);
+            //Debug.DrawLine(transform.position, _target.position, Color.green);
 
             // Calculate the depth of the focus point.
-            var d2 = Vector3.Dot(_target.position - transform.position, transform.forward);
+            var d2 = Vector3.Dot((FocusTarget?.position ?? new Vector3(Screen.width / 2, Screen.height / 2)) - transform.position, transform.forward);
             if (d2 < 0.1f)
                 d2 = 0.1f;
 
@@ -91,14 +97,15 @@ namespace AIGraphics
         void Focus(Vector3 PointOnScreen)
         {
             // our ray
-            var ray = transform.GetComponent<Camera>().ScreenPointToRay(PointOnScreen);
+            //var ray = transform.GetComponent<Camera>().ScreenPointToRay(PointOnScreen);
+            var ray = _parent.CameraSettings.MainCamera.ScreenPointToRay(PointOnScreen);
             if (Physics.Raycast(ray, out RaycastHit hit, maxDistance, hitLayer))
             {
-                Debug.DrawLine(ray.origin, hit.point);
+                //Debug.DrawLine(ray.origin, hit.point);
                 // do we have a new point?					
                 if (lastDoFPoint == hit.point)
                     return;
-                _target.position = hit.point;
+                FocusTarget.position = hit.point;
                 // asign the last hit
                 lastDoFPoint = hit.point;
             }

--- a/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
@@ -78,37 +78,40 @@ namespace AIGraphics.Inspector
             {
                 GUILayout.Label("Reflection Probes", GUIStyles.boldlabel);
                 ReflectionProbe[] rps = skyboxManager.GetReflectinProbes();
-                string[] probeNames = rps.Select(probe => probe.name).ToArray();                
-                selectedProbe = GUILayout.SelectionGrid(selectedProbe, probeNames, 3, GUIStyles.toolbarbutton);
-                ReflectionProbe rp = rps[selectedProbe];
-                GUILayout.Space(1);
-                GUILayout.BeginVertical(GUIStyles.Skin.box);
-                probeSettingsScrollView = GUILayout.BeginScrollView(probeSettingsScrollView);
+                if (0 < rps.Length)
                 {
-                    Label("Type", rp.mode.ToString());
-                    GUILayout.Label("Runtime settings");
-                    Slider("Importance", rp.importance, 0, 1000, importance => rp.importance = importance);
-                    Slider("Intensity", rp.intensity, 0, 10, "N2", intensity => rp.intensity = intensity);
-                    rp.boxProjection = Toggle("Box Projection", rp.boxProjection);
-                    rp.blendDistance = Text("Blend Distance", rp.blendDistance);
-                    Dimension("Box Size", rp.size, size => rp.size = size);
-                    Dimension("Box Offset", rp.center, size => rp.center = size);
-                    GUILayout.Space(10);
-                    GUILayout.Label("Cubemap capture settings");
-                    Selection("Resolution", rp.resolution, LightingSettings.ReflectionResolutions, resolution => rp.resolution = resolution);
-                    rp.hdr = Toggle("HDR", rp.hdr);                    
-                    rp.shadowDistance = Text("Shadow Distance", rp.shadowDistance);
-                    GUILayout.Label("Clear Flags");                    
-                    Selection("Clear Flags", rp.clearFlags, flag => rp.clearFlags = flag);                    
-                    SliderColor("Background", rp.backgroundColor, colour => { rp.backgroundColor = colour; });
-                    Label("Culling Mask", rp.cullingMask.ToString());
-                    rp.nearClipPlane = Text("Clipping Planes - Near", rp.nearClipPlane, "N1");
-                    rp.farClipPlane = Text("Clipping Planes - Far", rp.farClipPlane, "N1");
-                    Selection("Time Slicing Mode", rp.timeSlicingMode, mode => rp.timeSlicingMode = mode);
-                    
+                    string[] probeNames = rps.Select(probe => probe.name).ToArray();
+                    selectedProbe = GUILayout.SelectionGrid(selectedProbe, probeNames, 3, GUIStyles.toolbarbutton);
+                    ReflectionProbe rp = rps[selectedProbe];
+                    GUILayout.Space(1);
+                    GUILayout.BeginVertical(GUIStyles.Skin.box);
+                    probeSettingsScrollView = GUILayout.BeginScrollView(probeSettingsScrollView);
+                    {
+                        Label("Type", rp.mode.ToString());
+                        GUILayout.Label("Runtime settings");
+                        Slider("Importance", rp.importance, 0, 1000, importance => rp.importance = importance);
+                        Slider("Intensity", rp.intensity, 0, 10, "N2", intensity => rp.intensity = intensity);
+                        rp.boxProjection = Toggle("Box Projection", rp.boxProjection);
+                        rp.blendDistance = Text("Blend Distance", rp.blendDistance);
+                        Dimension("Box Size", rp.size, size => rp.size = size);
+                        Dimension("Box Offset", rp.center, size => rp.center = size);
+                        GUILayout.Space(10);
+                        GUILayout.Label("Cubemap capture settings");
+                        Selection("Resolution", rp.resolution, LightingSettings.ReflectionResolutions, resolution => rp.resolution = resolution);
+                        rp.hdr = Toggle("HDR", rp.hdr);
+                        rp.shadowDistance = Text("Shadow Distance", rp.shadowDistance);
+                        GUILayout.Label("Clear Flags");
+                        Selection("Clear Flags", rp.clearFlags, flag => rp.clearFlags = flag);
+                        SliderColor("Background", rp.backgroundColor, colour => { rp.backgroundColor = colour; });
+                        Label("Culling Mask", rp.cullingMask.ToString());
+                        rp.nearClipPlane = Text("Clipping Planes - Near", rp.nearClipPlane, "N1");
+                        rp.farClipPlane = Text("Clipping Planes - Far", rp.farClipPlane, "N1");
+                        Selection("Time Slicing Mode", rp.timeSlicingMode, mode => rp.timeSlicingMode = mode);
+
+                    }
+                    GUILayout.EndScrollView();
+                    GUILayout.EndVertical();
                 }
-                GUILayout.EndScrollView();
-                GUILayout.EndVertical();
             }
             GUILayout.EndVertical();            
             GUI.enabled = true;

--- a/AI_Graphics/AI_Graphics/SkyboxManager.cs
+++ b/AI_Graphics/AI_Graphics/SkyboxManager.cs
@@ -47,13 +47,14 @@ namespace AIGraphics
         private string cubemapPath;
         private FolderAssist CubemapFolder;
         
-        private GameObject probeParent;
-        private ReflectionProbe probe;
+        private ReflectionProbe _probe;
         private string isLoadingCubeMap = null; // to track currently used assetbundle path.
 
-        internal Camera Camera { get; set; }
-        internal AIGraphics Parent { get; set; }
+        internal ReflectionProbe DefaultProbe{ get => _probe ? DefaultReflectionProbe() : _probe; }
 
+        internal AIGraphics Parent { get; set; }
+        internal Camera Camera { get => Parent.CameraSettings.MainCamera; }
+        
         public bool Update { get; set; }
 
         internal BepInEx.Logging.ManualLogSource Logger { get; set; }
@@ -253,32 +254,32 @@ namespace AIGraphics
             yield break;
         }
 
-        internal void DefaultReflectionProbe()
+        internal ReflectionProbe DefaultReflectionProbe()
         {
-            probeParent = new GameObject("RealtimeReflectionProbe");
-            probe = probeParent.AddComponent<ReflectionProbe>();
-            probe.name = "Default Reflection Probe";
-            probe.mode = ReflectionProbeMode.Realtime;
-            probe.boxProjection = false;
-            probe.intensity = 1f;
-            probe.importance = 100;
-            probe.resolution = 512;
-            probe.backgroundColor = Color.white;
-            probe.hdr = true;
-            probe.cullingMask = 1 | ~Camera.cullingMask;
-            probe.clearFlags = ReflectionProbeClearFlags.Skybox;
-            probe.size = new Vector3(10, 10, 10);
-            probe.nearClipPlane = 1;
-            probeParent.transform.position = new Vector3(0, 0, 0);
-            probe.refreshMode = ReflectionProbeRefreshMode.EveryFrame;
-            probe.timeSlicingMode = ReflectionProbeTimeSlicingMode.AllFacesAtOnce;
+            _probe = this.GetOrAddComponent<ReflectionProbe>();
+            _probe.name = "Default Reflection Probe";
+            _probe.mode = ReflectionProbeMode.Realtime;
+            _probe.boxProjection = false;
+            _probe.intensity = 1f;
+            _probe.importance = 100;
+            _probe.resolution = 512;
+            _probe.backgroundColor = Color.white;
+            _probe.hdr = true;
+            _probe.cullingMask = 1 | ~Camera.cullingMask;
+            _probe.clearFlags = ReflectionProbeClearFlags.Skybox;
+            _probe.size = new Vector3(10, 10, 10);
+            _probe.nearClipPlane = 1;
+            _probe.transform.position = new Vector3(0, 0, 0);
+            _probe.refreshMode = ReflectionProbeRefreshMode.EveryFrame;
+            _probe.timeSlicingMode = ReflectionProbeTimeSlicingMode.AllFacesAtOnce;
+            return _probe;
         }
 
         internal void SetupDefaultReflectionProbe()
         {
             ReflectionProbe[] rps = GetReflectinProbes();
             //disable default realtime reflection probe if scene has realtime reflection probes.
-            probe.intensity = (rps.Select(probe => probe.mode == ReflectionProbeMode.Realtime).ToArray().Length > 1) ? 0 : 1;
+            DefaultProbe.intensity = (rps.Select(probe => probe.mode == ReflectionProbeMode.Realtime).ToArray().Length > 1) ? 0 : 1;
         }
 
         internal ReflectionProbe[] GetReflectinProbes()


### PR DESCRIPTION
GameObjects get destroyed when leaving the maker scene. Get skymanager, pp manager and focuspuller to attach to AIGraphics instance instead.

This partially fixes #12 . NPEs are now on ppinspector on re-entering maker. In the meantime, I want you to see and have this MR