### PR TITLE
Add value slider to lift/gamma/gain tint controls

### DIFF
--- a/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
@@ -134,14 +134,7 @@ namespace AIGraphics.Inspector
             }
 
             GUI.color = new Color(value.r, value.g, value.b, 1f);
-
-            GUILayout.Box(colourIndicator);
-
-            GUI.color = Color.black;
-            GUILayout.Box(colourIndicator);
-            GUI.color = new Color(value.r, value.g, value.b, value.a);
-            GUI.Box(GUILayoutUtility.GetLastRect(), colourIndicator);
-            
+            GUILayout.Label(colourIndicator);
             GUI.color = Color.white;
             GUILayout.EndHorizontal();
             GUILayout.BeginVertical();

--- a/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
@@ -123,6 +123,63 @@ namespace AIGraphics.Inspector
             }
         }
 
+        internal static void SliderTrackball(string label, Color value, Action<Color> onChanged = null, bool useColorDisplayColor32 = false, bool enable = true, Action<bool> onChangedEnable = null)
+        {
+            GUILayout.BeginHorizontal();
+            int spacing = 0;
+            EnableToggle(label, ref spacing, ref enable, onChangedEnable);
+            if (!enable)
+            {
+                GUI.enabled = false;
+            }
+
+            GUI.color = new Color(value.r, value.g, value.b, 1f);
+
+            GUILayout.Box(colourIndicator);
+
+            GUI.color = Color.black;
+            GUILayout.Box(colourIndicator);
+            GUI.color = new Color(value.r, value.g, value.b, value.a);
+            GUI.Box(GUILayoutUtility.GetLastRect(), colourIndicator);
+            
+            GUI.color = Color.white;
+            GUILayout.EndHorizontal();
+            GUILayout.BeginVertical();
+            if (useColorDisplayColor32)
+            {
+                Color color = value;
+                color.r = SliderColor("Red", color.r, spacing);
+                color.g = SliderColor("Green", color.g, spacing);
+                color.b = SliderColor("Blue", color.b, spacing);
+                color.a = SliderColorFloat("Value", color.a, -5f, 5f, spacing);
+                Color newValue = color;
+                if (onChanged != null && value != newValue)
+                {
+                    onChanged(newValue);
+                }
+            }
+            else
+            {
+                Color32 color = value;
+                color.r = SliderColor("Red", color.r, spacing);
+                color.g = SliderColor("Green", color.g, spacing);
+                color.b = SliderColor("Blue", color.b, spacing);
+                // This value needs to be a float even when using a Color32 since the value is out of the 0, 1 (or 0-255) range
+                float alpha = SliderColorFloat("Value", value.a, -5f, 5f, spacing);
+                Color newValue = color;
+                newValue.a = alpha;
+                if (onChanged != null && value != newValue)
+                {
+                    onChanged(newValue);
+                }
+            }
+            GUILayout.EndVertical();
+            if (!enable)
+            {
+                GUI.enabled = true;
+            }
+        }
+
         internal static float SliderColor(string label, float value, int spacing)
         {
             GUILayout.BeginHorizontal();
@@ -164,6 +221,30 @@ namespace AIGraphics.Inspector
             if (newValueString != valueString)
             {
                 if (byte.TryParse(newValueString, out byte parseResult))
+                {
+                    newValue = parseResult;
+                }
+            }
+            return newValue;
+        }
+
+        internal static float SliderColorFloat(string label, float value, float minValue, float maxValue, int spacing)
+        {
+            GUILayout.BeginHorizontal();
+            if (0 != spacing)
+            {
+                GUILayout.Label("", GUILayout.Width(spacing));
+            }
+
+            GUILayout.Label(label, GUILayout.ExpandWidth(false));
+            GUILayout.Label("", GUILayout.Width(GUIStyles.labelWidth - GUI.skin.label.CalcSize(new GUIContent(label)).x - spacing));
+            float newValue = GUILayout.HorizontalSlider(value, minValue, maxValue);
+            string valueString = value.ToString();
+            string newValueString = GUILayout.TextField(newValue.ToString(), GUILayout.Width(40), GUILayout.ExpandWidth(false));
+            GUILayout.EndHorizontal();
+            if (newValueString != valueString)
+            {
+                if (float.TryParse(newValueString, out float parseResult))
                 {
                     newValue = parseResult;
                 }

--- a/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
@@ -288,11 +288,11 @@ namespace AIGraphics.Inspector
                         }
                         Slider("Contrast", settings.colorGradingLayer.contrast.value, -100, 100, "N1", contrast => settings.colorGradingLayer.contrast.value = contrast,
                             settings.colorGradingLayer.contrast.overrideState, overrideState => settings.colorGradingLayer.contrast.overrideState = overrideState);
-                        SliderColor("Lift", settings.colorGradingLayer.lift.value, colour => settings.colorGradingLayer.lift.value = colour, false,
+                        SliderTrackball("Lift", settings.colorGradingLayer.lift.value, colour => settings.colorGradingLayer.lift.value = colour, false,
                             settings.colorGradingLayer.lift.overrideState, overrideState => settings.colorGradingLayer.lift.overrideState = overrideState);
-                        SliderColor("Gamma", settings.colorGradingLayer.gamma.value, colour => settings.colorGradingLayer.gamma.value = colour, false,
+                        SliderTrackball("Gamma", settings.colorGradingLayer.gamma.value, colour => settings.colorGradingLayer.gamma.value = colour, false,
                             settings.colorGradingLayer.gamma.overrideState, overrideSate => settings.colorGradingLayer.gamma.overrideState = overrideSate);
-                        SliderColor("Gain", settings.colorGradingLayer.gain.value, colour => settings.colorGradingLayer.gain.value = colour, false,
+                        SliderTrackball("Gain", settings.colorGradingLayer.gain.value, colour => settings.colorGradingLayer.gain.value = colour, false,
                             settings.colorGradingLayer.gain.overrideState, overrideSate => settings.colorGradingLayer.gain.overrideState = overrideSate);
                     }
                     else


### PR DESCRIPTION
I just got AIGraphics and noticed that the color grading GUI for lift/gamma/gain doesn't include a slider for the value (unsure of the exact terminology), just the color tint. This PR adds a slider to each control.
![StudioNEOV2_2020-04-23_23-20-11](https://user-images.githubusercontent.com/54485138/80172458-0d7e9700-85bb-11ea-9fec-6854c3d3edc3.png)
The value sliders are handy for tweaking the brightness of shadows, midtones and highlights, which the color sliders alone do not have influence over (I suppose the color grading effect normalizes the color).