### PR TITLE
Bug reflection

### DIFF
--- a/AI_Graphics/AI_Graphics/AIGraphics.cs
+++ b/AI_Graphics/AI_Graphics/AIGraphics.cs
@@ -94,6 +94,7 @@ namespace AIGraphics
             {
                 StartCoroutine(InitializeLight(scene));
             }
+            CullingMaskExtensions.RefreshLayers();
         }
 
         private IEnumerator InitializeLight(Scene scene)

--- a/AI_Graphics/AI_Graphics/AIGraphics.csproj
+++ b/AI_Graphics/AI_Graphics/AIGraphics.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Alloy\AlloyPropertyAttributes.cs" />
     <Compile Include="Alloy\AlloyUtils.cs" />
     <Compile Include="Alloy\AreaLight\AlloyAreaLight.cs" />
+    <Compile Include="CullingMaskExtensions.cs" />
     <Compile Include="FocusPuller.cs" />
     <Compile Include="Inspector\LightingInspector.cs" />
     <Compile Include="Inspector\LightInspector.cs" />

--- a/AI_Graphics/AI_Graphics/CullingMaskExtensions.cs
+++ b/AI_Graphics/AI_Graphics/CullingMaskExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace AIGraphics
+{
+    //https://www.gamasutra.com/blogs/CharlesCordingley/20141124/230710/Unity3D_Culling_Mask_Tip.php
+    internal static class CullingMaskExtensions
+    {
+        internal static List<string> Layers { get; private set; }
+
+        internal static void RefreshLayers()
+        {
+            List<string> layers = new List<string>();
+            for (int i = 0; i <= 31; i++)
+            {
+                var layerN = LayerMask.LayerToName(i);
+                if (layerN.Length > 0)
+                    layers.Add(layerN);
+            }
+            Layers = layers;
+        }
+
+        internal static int LayerCullingShow(int cullingMask, int layerMask)
+        {
+            cullingMask |= layerMask;
+            return cullingMask;
+        }
+
+        internal static int LayerCullingShow(int cullingMask, string layer)
+        {
+            return LayerCullingShow(cullingMask, 1 << LayerMask.NameToLayer(layer));
+        }
+
+        internal static int LayerCullingHide(int cullingMask, int layerMask)
+        {
+            cullingMask &= ~layerMask;
+            return cullingMask;
+        }
+
+        internal static int LayerCullingHide(int cullingMask, string layer)
+        {
+            return LayerCullingHide(cullingMask, 1 << LayerMask.NameToLayer(layer));
+        }
+
+        internal static int LayerCullingToggle(int cullingMask, int layerMask)
+        {
+            cullingMask ^= layerMask;
+            return cullingMask;
+        }
+
+        internal static int LayerCullingToggle(int cullingMask, string layer)
+        {
+            return LayerCullingToggle(cullingMask, 1 << LayerMask.NameToLayer(layer));
+        }
+
+        internal static bool LayerCullingIncludes(int cullingMask, int layerMask)
+        {
+            return (cullingMask & layerMask) > 0;
+        }
+
+        internal static bool LayerCullingIncludes(int cullingMask, string layer)
+        {
+            return LayerCullingIncludes(cullingMask, 1 << LayerMask.NameToLayer(layer));
+        }
+
+        internal static int LayerCullingToggle(int cullingMask, int layerMask, bool isOn)
+        {
+            bool included = LayerCullingIncludes(cullingMask, layerMask);
+            if (isOn && !included)
+            {
+                return LayerCullingShow(cullingMask, layerMask);
+            }
+            else if (!isOn && included)
+            {
+                return LayerCullingHide(cullingMask, layerMask);
+            }
+            return cullingMask;
+        }
+
+        internal static int LayerCullingToggle(int cullingMask, string layer, bool isOn)
+        {
+            return LayerCullingToggle(cullingMask, 1 << LayerMask.NameToLayer(layer), isOn);
+        }
+    }
+}

--- a/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/GUIUtility.cs
@@ -339,6 +339,37 @@ namespace AIGraphics.Inspector
             return selectedIndex;
         }
 
+        internal static void SelectionMask(string label, int cullingMask, Action<int> onChanged = null, int columns = 4)
+        {
+            int newMask = cullingMask;
+            GUILayout.BeginHorizontal();
+            GUILayout.Label(label, GUILayout.ExpandWidth(false));
+            GUILayout.Label("", GUILayout.Width(GUIStyles.labelWidth - GUI.skin.label.CalcSize(new GUIContent(label)).x));
+            int included = 0;
+            GUILayout.BeginVertical();
+            for (int i = 0; i < CullingMaskExtensions.Layers.Count; i++)
+            {
+                string layer = CullingMaskExtensions.Layers[i];
+                bool include = CullingMaskExtensions.LayerCullingIncludes(newMask, layer);
+                if (0 == (i % columns))
+                    GUILayout.BeginHorizontal();
+                include = GUILayout.Toggle(include, layer, GUIStyles.Skin.button);
+                included++;
+                newMask = CullingMaskExtensions.LayerCullingToggle(newMask, layer, include);
+                if (included == columns)
+                {
+                    GUILayout.EndHorizontal();
+                    included = 0;
+                }
+            }
+            if (0 != included)
+                GUILayout.EndHorizontal();
+            GUILayout.EndVertical();
+            GUILayout.EndHorizontal();
+            if (newMask != cullingMask)
+                onChanged(newMask);
+        }
+
         internal static TEnum Toolbar<TEnum>(TEnum selected)
         {
             GUILayout.BeginHorizontal();

--- a/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/Inspector.cs
@@ -85,7 +85,7 @@ namespace AIGraphics.Inspector
                     PresetInspector.Draw(Parent.PresetManager);
                     break;
                 case Tab.Settings:
-                    SettingsInspector.Draw(Parent.CameraSettings, Parent.Settings, Parent);
+                    SettingsInspector.Draw(Parent.CameraSettings, Parent.Settings, Parent.Settings.ShowAdvancedSettings);
                     break;
             }
         }

--- a/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
@@ -103,17 +103,20 @@ namespace AIGraphics.Inspector
                         Dimension("Box Offset", rp.center, size => rp.center = size);
                         GUILayout.Space(10);
                         GUILayout.Label("Cubemap capture settings");
-                        Selection("Resolution", rp.resolution, LightingSettings.ReflectionResolutions, resolution => rp.resolution = resolution);
+                        Selection("Resolution", rp.resolution, LightingSettings.ReflectionResolutions, resolution => rp.resolution = resolution);                        
                         rp.hdr = Toggle("HDR", rp.hdr);
                         rp.shadowDistance = Text("Shadow Distance", rp.shadowDistance);
                         GUILayout.Label("Clear Flags");
                         Selection("Clear Flags", rp.clearFlags, flag => rp.clearFlags = flag);
+                        if (showAdvanced)
+                        {
+                            SelectionMask("Culling Mask", rp.cullingMask, mask => rp.cullingMask = mask);
+                            Label("Culling Mask", rp.cullingMask.ToString());
+                        }
+                        rp.nearClipPlane = Text("Clipping Planes - Near", rp.nearClipPlane, "N2");
+                        rp.farClipPlane = Text("Clipping Planes - Far", rp.farClipPlane, "N2");
                         SliderColor("Background", rp.backgroundColor, colour => { rp.backgroundColor = colour; });
-                        Label("Culling Mask", rp.cullingMask.ToString());
-                        rp.nearClipPlane = Text("Clipping Planes - Near", rp.nearClipPlane, "N1");
-                        rp.farClipPlane = Text("Clipping Planes - Far", rp.farClipPlane, "N1");
                         Selection("Time Slicing Mode", rp.timeSlicingMode, mode => rp.timeSlicingMode = mode);
-
                     }
                     GUILayout.EndScrollView();
                     GUILayout.EndVertical();

--- a/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/LightingInspector.cs
@@ -111,7 +111,6 @@ namespace AIGraphics.Inspector
                         if (showAdvanced)
                         {
                             SelectionMask("Culling Mask", rp.cullingMask, mask => rp.cullingMask = mask);
-                            Label("Culling Mask", rp.cullingMask.ToString());
                         }
                         rp.nearClipPlane = Text("Clipping Planes - Near", rp.nearClipPlane, "N2");
                         rp.farClipPlane = Text("Clipping Planes - Far", rp.farClipPlane, "N2");

--- a/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/PostProcessingInspector.cs
@@ -353,7 +353,20 @@ namespace AIGraphics.Inspector
                 {
                     Selection("Preset", settings.screenSpaceReflectionsLayer.preset.value, preset => settings.screenSpaceReflectionsLayer.preset.value = preset, -1,
                         settings.screenSpaceReflectionsLayer.preset.overrideState, overrideState => settings.screenSpaceReflectionsLayer.preset.overrideState = overrideState);
-                    Text("Maximum March Distance", settings.screenSpaceReflectionsLayer.maximumMarchDistance.value, "N2",
+
+                    if (ScreenSpaceReflectionPreset.Custom == settings.screenSpaceReflectionsLayer.preset.value)
+                    {
+                        Slider("Maximum Iteration Count", settings.screenSpaceReflectionsLayer.maximumIterationCount.value, 0, 256, iteration => settings.screenSpaceReflectionsLayer.maximumIterationCount.value = iteration,
+                            settings.screenSpaceReflectionsLayer.maximumIterationCount.overrideState, overrideState => settings.screenSpaceReflectionsLayer.maximumIterationCount.overrideState = overrideState);
+
+                        Slider("Thickness", settings.screenSpaceReflectionsLayer.thickness.value, 1f, 64f, "N1", thickness => settings.screenSpaceReflectionsLayer.thickness.value = thickness,
+                            settings.screenSpaceReflectionsLayer.thickness.overrideState, overrideState => settings.screenSpaceReflectionsLayer.thickness.overrideState = overrideState);
+
+                        Selection("Resolution", settings.screenSpaceReflectionsLayer.resolution.value, resolution => settings.screenSpaceReflectionsLayer.resolution.value = resolution, -1,
+                            settings.screenSpaceReflectionsLayer.resolution.overrideState, overrideState => settings.screenSpaceReflectionsLayer.resolution.overrideState = overrideState);
+                    }
+
+                    settings.screenSpaceReflectionsLayer.maximumMarchDistance.value = Text("Maximum March Distance", settings.screenSpaceReflectionsLayer.maximumMarchDistance.value, "N2",
                         settings.screenSpaceReflectionsLayer.maximumMarchDistance.overrideState, overrideState => settings.screenSpaceReflectionsLayer.maximumMarchDistance.overrideState = overrideState);
                     Slider("Distance Fade", settings.screenSpaceReflectionsLayer.distanceFade, 0f, 1f, "N3", fade => settings.screenSpaceReflectionsLayer.distanceFade.value = fade,
                         settings.screenSpaceReflectionsLayer.distanceFade.overrideState, overrideState => settings.screenSpaceReflectionsLayer.distanceFade.overrideState = overrideState);

--- a/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
@@ -18,9 +18,9 @@ namespace AIGraphics.Inspector
                 cameraSettings.ClearFlag = Selection("Clear Flags", cameraSettings.ClearFlag, flag => cameraSettings.ClearFlag = flag);
                 if (showAdvanced)
                 {
+                    //changing studio camera's culling mask breaks studio, possibly due to cinemachine
                     GUI.enabled = false; 
-                    SelectionMask("Culling Mask", cameraSettings.CullingMask, mask => cameraSettings.CullingMask = mask);
-                    Label("Culling Mask", cameraSettings.CullingMask.ToString());
+                    SelectionMask("Culling Mask", cameraSettings.CullingMask, mask => cameraSettings.CullingMask = mask);                    
                     GUI.enabled = true;
                 }
                 Slider("Near Clipping Plane", cameraSettings.NearClipPlane, 0.01f, 15000f, "N2", ncp => { cameraSettings.NearClipPlane = ncp; });

--- a/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
+++ b/AI_Graphics/AI_Graphics/Inspector/SettingsInspector.cs
@@ -10,12 +10,19 @@ namespace AIGraphics.Inspector
         private const float FOVMax = 120f;
         private const float FOVDefault = 23.5f;
 
-        internal static void Draw(CameraSettings cameraSettings, GlobalSettings renderingSettings, AIGraphics parent)
+        internal static void Draw(CameraSettings cameraSettings, GlobalSettings renderingSettings, bool showAdvanced)
         {
             GUILayout.BeginVertical(GUIStyles.Skin.box);
             {
                 GUILayout.Label("Camera", GUIStyles.boldlabel);
                 cameraSettings.ClearFlag = Selection("Clear Flags", cameraSettings.ClearFlag, flag => cameraSettings.ClearFlag = flag);
+                if (showAdvanced)
+                {
+                    GUI.enabled = false; 
+                    SelectionMask("Culling Mask", cameraSettings.CullingMask, mask => cameraSettings.CullingMask = mask);
+                    Label("Culling Mask", cameraSettings.CullingMask.ToString());
+                    GUI.enabled = true;
+                }
                 Slider("Near Clipping Plane", cameraSettings.NearClipPlane, 0.01f, 15000f, "N2", ncp => { cameraSettings.NearClipPlane = ncp; });
                 Slider("Far Clipping Plane", cameraSettings.FarClipPlane, 0.01f, 15000f, "N2", ncp => { cameraSettings.FarClipPlane = ncp; });
                 Selection("Rendering Path", cameraSettings.RenderingPath, path => cameraSettings.RenderingPath = path);

--- a/AI_Graphics/AI_Graphics/Setting/CameraSettings.cs
+++ b/AI_Graphics/AI_Graphics/Setting/CameraSettings.cs
@@ -50,6 +50,16 @@ namespace AIGraphics.Settings
             set => _clearFlags = MainCamera.clearFlags = (CameraClearFlags)value;
         }
 
+        public int CullingMask
+        {
+            get => MainCamera.cullingMask;
+            set
+            {
+                Debug.Log("setting culling mask from " + MainCamera.cullingMask + " to " + value);
+                //MainCamera.cullingMask = value;
+            }
+        }
+
         public AIRenderingPath RenderingPath
         {
             get => (AIRenderingPath)MainCamera.renderingPath;

--- a/AI_Graphics/AI_Graphics/Texture/SkyboxManager.cs
+++ b/AI_Graphics/AI_Graphics/Texture/SkyboxManager.cs
@@ -40,8 +40,9 @@ namespace AIGraphics.Textures
 
         internal static string noCubemap = "No skybox";
         private string selectedCubeMap = noCubemap;
-
+        
         private ReflectionProbe _probe;
+        private GameObject _probeGameObject;
 
         internal ReflectionProbe DefaultProbe => _probe ? DefaultReflectionProbe() : _probe;
 
@@ -261,22 +262,27 @@ namespace AIGraphics.Textures
 
         internal ReflectionProbe DefaultReflectionProbe()
         {
-            _probe = this.GetOrAddComponent<ReflectionProbe>();
-            //_probe.name = "Default Reflection Probe";
-            _probe.mode = ReflectionProbeMode.Realtime;
-            _probe.boxProjection = false;
-            _probe.intensity = 1f;
-            _probe.importance = 100;
-            _probe.resolution = 512;
-            _probe.backgroundColor = Color.white;
-            _probe.hdr = true;
-            _probe.clearFlags = ReflectionProbeClearFlags.Skybox;
-            _probe.cullingMask = Camera.cullingMask;
-            _probe.size = new Vector3(100, 100, 100);
-            _probe.nearClipPlane = 1;
-            _probe.transform.position = new Vector3(0, 0, 0);
-            _probe.refreshMode = ReflectionProbeRefreshMode.EveryFrame;
-            _probe.timeSlicingMode = ReflectionProbeTimeSlicingMode.AllFacesAtOnce;
+            if (null == _probeGameObject || null == _probe)
+            {
+                _probeGameObject = new GameObject("Default Reflection Probe");
+                _probe = _probeGameObject.GetOrAddComponent<ReflectionProbe>();                
+                _probe.mode = ReflectionProbeMode.Realtime;
+                _probe.boxProjection = false;
+                _probe.intensity = 1f;
+                _probe.importance = 100;
+                _probe.resolution = 512;
+                _probe.backgroundColor = Color.white;
+                _probe.hdr = true;
+                _probe.clearFlags = ReflectionProbeClearFlags.Skybox;
+                _probe.cullingMask = Camera.cullingMask;
+                _probe.size = new Vector3(100, 100, 100);
+                _probe.nearClipPlane = 0.01f;
+                _probe.transform.position = new Vector3(0, 0, 0);
+                _probe.refreshMode = ReflectionProbeRefreshMode.EveryFrame;
+                _probe.timeSlicingMode = ReflectionProbeTimeSlicingMode.AllFacesAtOnce;
+                DontDestroyOnLoad(_probeGameObject);
+                DontDestroyOnLoad(_probe);
+            }
             return _probe;
         }
 

--- a/AI_Graphics/AI_Graphics/Texture/SkyboxManager.cs
+++ b/AI_Graphics/AI_Graphics/Texture/SkyboxManager.cs
@@ -270,9 +270,9 @@ namespace AIGraphics.Textures
             _probe.resolution = 512;
             _probe.backgroundColor = Color.white;
             _probe.hdr = true;
-            _probe.cullingMask = 1 | ~Camera.cullingMask;
             _probe.clearFlags = ReflectionProbeClearFlags.Skybox;
-            _probe.size = new Vector3(10, 10, 10);
+            _probe.cullingMask = Camera.cullingMask;
+            _probe.size = new Vector3(100, 100, 100);
             _probe.nearClipPlane = 1;
             _probe.transform.position = new Vector3(0, 0, 0);
             _probe.refreshMode = ReflectionProbeRefreshMode.EveryFrame;


### PR DESCRIPTION
fixes #20 #53 #69 #75 

* ability to inspect/modify culling mask
* set culling mask of default reflection probe to that of the camera
* expose custom ssr options
* maintain the default reflection probe in its own GO and keep it around for main game/chara maker sessions